### PR TITLE
Update Radio removal to only remove when it's the last word

### DIFF
--- a/custom_components/pandora_patiobar/coordinator.py
+++ b/custom_components/pandora_patiobar/coordinator.py
@@ -81,8 +81,8 @@ class PatiobarCoordinator(DataUpdateCoordinator):
         # Remove trailing numbers in parentheses (e.g. "Station Name (1)" -> "Station Name")
         cleaned = re.sub(r'\s*\(\d+\)$', '', cleaned)
         
-        # Remove the word "Radio" (case-insensitive, with word boundaries)
-        cleaned = re.sub(r'\bRadio\b', '', cleaned, flags=re.IGNORECASE)
+        # Remove the word "Radio" only if it's the last word (case-insensitive)
+        cleaned = re.sub(r'\bRadio\s*$', '', cleaned, flags=re.IGNORECASE)
         
         # Clean up multiple spaces and leading/trailing whitespace
         cleaned = re.sub(r'\s+', ' ', cleaned).strip()


### PR DESCRIPTION
- Changed regex from '\bRadio\b' to '\bRadio\s*$'
- Now only removes 'Radio' when it appears at the end of station names
- Preserves stations like 'Radio Disney' but cleans 'Classic Rock Radio'
- Examples: 'Classic Rock Radio' -> 'Classic Rock', but 'Radio Disney' stays unchanged