### PR TITLE
Fix service registration and media player button display

### DIFF
--- a/custom_components/pandora_patiobar/media_player.py
+++ b/custom_components/pandora_patiobar/media_player.py
@@ -22,8 +22,7 @@ from .coordinator import PatiobarCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_PATIOBAR = (
-    MediaPlayerEntityFeature.PAUSE
-    | MediaPlayerEntityFeature.PLAY
+    MediaPlayerEntityFeature.PLAY_PAUSE
     | MediaPlayerEntityFeature.NEXT_TRACK
     | MediaPlayerEntityFeature.VOLUME_SET
     | MediaPlayerEntityFeature.SELECT_SOURCE
@@ -46,13 +45,13 @@ async def async_setup_entry(
     platform = async_get_current_platform()
     
     platform.async_register_entity_service(
-        "thumbs_up",
+        "media_thumbs_up",
         {},
         "async_thumbs_up",
     )
     
     platform.async_register_entity_service(
-        "thumbs_down", 
+        "media_thumbs_down", 
         {},
         "async_thumbs_down",
     )
@@ -180,6 +179,13 @@ class PatiobarMediaPlayer(CoordinatorEntity, MediaPlayerEntity):
             attributes["song_station"] = song_info["songStationName"]
             
         return attributes
+
+    async def async_media_play_pause(self) -> None:
+        """Toggle play/pause."""
+        if self.coordinator.is_playing:
+            await self.coordinator.async_media_pause()
+        else:
+            await self.coordinator.async_media_play()
 
     async def async_media_play(self) -> None:
         """Send play command."""


### PR DESCRIPTION
- Fix service name mismatch: use media_thumbs_up/media_thumbs_down in registration
- Replace separate PLAY/PAUSE features with PLAY_PAUSE for proper UI behavior
- Add async_media_play_pause() toggle method for better user experience
- Media player card will now show correct play/pause button based on state
- Keep individual play/pause methods for backward compatibility