### PR TITLE
Add improved play/pause state handling and debugging

### DIFF
--- a/custom_components/pandora_patiobar/coordinator.py
+++ b/custom_components/pandora_patiobar/coordinator.py
@@ -247,6 +247,25 @@ class PatiobarCoordinator(DataUpdateCoordinator):
             self._is_playing = data.get("isplaying", self._is_playing)
             self.async_set_updated_data(await self._async_update_data())
         
+        elif event == "pause" or event == "play":
+            # Handle play/pause state changes
+            self._is_playing = (event == "play")
+            _LOGGER.info("Play/pause state changed: %s (is_playing: %s)", event, self._is_playing)
+            self.async_set_updated_data(await self._async_update_data())
+        
+        elif event == "status":
+            # Handle status updates that might include play state
+            if "isplaying" in data:
+                self._is_playing = data.get("isplaying", False)
+            if "isrunning" in data:
+                self._is_running = data.get("isrunning", False)
+            if "volume" in data:
+                self._volume = data.get("volume", 50)
+            # Update song info if present
+            if any(key in data for key in ["title", "artist", "album", "stationName"]):
+                self._current_song.update(data)
+            self.async_set_updated_data(await self._async_update_data())
+        
         # Catch-all for any unrecognized events that might contain station data
         else:
             _LOGGER.debug("Unrecognized websocket event: '%s' with data: %s", event, data)
@@ -266,6 +285,17 @@ class PatiobarCoordinator(DataUpdateCoordinator):
                 if "title" in data or "artist" in data or "stationName" in data:
                     _LOGGER.debug("Updating song info from unknown event '%s'", event)
                     self._current_song.update(data)
+                    
+                # Check for play state in unknown events
+                if "isplaying" in data:
+                    self._is_playing = data.get("isplaying", False)
+                    _LOGGER.info("Updated playing state from unknown event '%s': %s", event, self._is_playing)
+                    
+                if "isrunning" in data:
+                    self._is_running = data.get("isrunning", False)
+                    
+                # Trigger update if any relevant data was found
+                if any(key in data for key in ["title", "artist", "stationName", "isplaying", "isrunning"]):
                     self.async_set_updated_data(await self._async_update_data())
 
     # Media control methods

--- a/custom_components/pandora_patiobar/media_player.py
+++ b/custom_components/pandora_patiobar/media_player.py
@@ -91,9 +91,14 @@ class PatiobarMediaPlayer(CoordinatorEntity, MediaPlayerEntity):
     @property
     def state(self) -> MediaPlayerState:
         """Return the state of the media player."""
-        if not self.coordinator.is_running:
+        is_running = self.coordinator.is_running
+        is_playing = self.coordinator.is_playing
+        
+        _LOGGER.debug("Media player state check - is_running: %s, is_playing: %s", is_running, is_playing)
+        
+        if not is_running:
             return MediaPlayerState.OFF
-        elif self.coordinator.is_playing:
+        elif is_playing:
             return MediaPlayerState.PLAYING
         else:
             return MediaPlayerState.PAUSED


### PR DESCRIPTION
- Add handlers for 'play', 'pause', and 'status' websocket events
- Improve play state detection in catch-all event handlers
- Add debug logging to media player state property
- Better handling of isplaying/isrunning state updates from websocket
- This should fix the play/pause button always showing pause icon