### PR TITLE
Try to sync volume slider

### DIFF
--- a/custom_components/pandora_patiobar/coordinator.py
+++ b/custom_components/pandora_patiobar/coordinator.py
@@ -265,7 +265,9 @@ class PatiobarCoordinator(DataUpdateCoordinator):
         # Audio control
         if "volume" in data:
             old_volume = self._volume
-            self._volume = data.get("volume", 50)
+            volume_value = data.get("volume")
+            # Use volume if provided and valid, otherwise keep current or default to 50
+            self._volume = volume_value if volume_value is not None else self._volume or 50
             if old_volume != self._volume:
                 _LOGGER.info("🎵 FOUND volume: %s -> %s (%s)", old_volume, self._volume, source)
                 state_updated = True

--- a/custom_components/pandora_patiobar/media_player.py
+++ b/custom_components/pandora_patiobar/media_player.py
@@ -108,6 +108,8 @@ class PatiobarMediaPlayer(CoordinatorEntity, MediaPlayerEntity):
     @property
     def volume_level(self) -> float | None:
         """Volume level of the media player (0..1)."""
+        if self.coordinator.volume is None:
+            return None
         return self.coordinator.volume / 100.0
 
     @property


### PR DESCRIPTION
- Add None protection to volume_level property to prevent TypeError crashes
- Implement robust volume handling with safe fallback logic
- Prevents integration crashes when volume data is missing
- Ensures websocket connections remain stable

Fixes:
- TypeError in volume_level when coordinator.volume is None
- Async event loop crashes that break websocket connections
- Integration failures after volume-related commits