### PR TITLE
Change key debug messages back to WARNING level

### DIFF
--- a/custom_components/pandora_patiobar/coordinator.py
+++ b/custom_components/pandora_patiobar/coordinator.py
@@ -253,13 +253,13 @@ class PatiobarCoordinator(DataUpdateCoordinator):
             old_playing = self._is_playing
             self._is_playing = data.get("pianobarPlaying", False)
             if old_playing != self._is_playing:
-                _LOGGER.info("🎵 FOUND pianobarPlaying: %s -> %s (%s)", old_playing, self._is_playing, source)
+                _LOGGER.warning("🎵 FOUND pianobarPlaying: %s -> %s (%s)", old_playing, self._is_playing, source)
                 state_updated = True
         elif "isplaying" in data:
             old_playing = self._is_playing
             self._is_playing = data.get("isplaying", False)
             if old_playing != self._is_playing:
-                _LOGGER.info("🎵 FOUND isplaying: %s -> %s (%s)", old_playing, self._is_playing, source)
+                _LOGGER.warning("🎵 FOUND isplaying: %s -> %s (%s)", old_playing, self._is_playing, source)
                 state_updated = True
                 
         # Audio control
@@ -310,7 +310,7 @@ class PatiobarCoordinator(DataUpdateCoordinator):
 
     async def _process_websocket_event(self, event: str, data: dict[str, Any]) -> None:
         """Process websocket events."""
-        _LOGGER.info("🎵 WEBSOCKET EVENT: '%s' with data: %s", event, data)
+        _LOGGER.warning("🎵 WEBSOCKET EVENT: '%s' with data: %s", event, data)
         
         # Update state from scope data (handles all common scope fields)
         state_updated = self._update_from_scope_data(data, f"event:{event}")
@@ -356,7 +356,7 @@ class PatiobarCoordinator(DataUpdateCoordinator):
                 # Play/pause toggle - temporarily update state then wait for websocket confirmation
                 old_state = self._is_playing
                 self._is_playing = not self._is_playing
-                _LOGGER.info("🎵 PLAY/PAUSE TOGGLE - temporary state: %s -> %s (waiting for pianobarPlaying confirmation)", old_state, self._is_playing)
+                _LOGGER.warning("🎵 PLAY/PAUSE TOGGLE - temporary state: %s -> %s (waiting for pianobarPlaying confirmation)", old_state, self._is_playing)
                 self.async_set_updated_data(await self._async_update_data())
                 
                 # Request status to get actual pianobarPlaying state
@@ -384,7 +384,7 @@ class PatiobarCoordinator(DataUpdateCoordinator):
     async def async_media_play(self) -> None:
         """Send play command."""
         try:
-            _LOGGER.info("🎵 SENDING PLAY COMMAND - current is_playing: %s", self._is_playing)
+            _LOGGER.warning("🎵 SENDING PLAY COMMAND - current is_playing: %s", self._is_playing)
             if self.websocket:
                 # Use pianobar "p" command for play/pause toggle
                 message = '42["action", {"action": "p"}]'
@@ -399,7 +399,7 @@ class PatiobarCoordinator(DataUpdateCoordinator):
     async def async_media_pause(self) -> None:
         """Send pause command."""
         try:
-            _LOGGER.info("🎵 SENDING PAUSE COMMAND - current is_playing: %s", self._is_playing)
+            _LOGGER.warning("🎵 SENDING PAUSE COMMAND - current is_playing: %s", self._is_playing)
             if self.websocket:
                 # Use pianobar "p" command for play/pause toggle
                 message = '42["action", {"action": "p"}]'

--- a/custom_components/pandora_patiobar/media_player.py
+++ b/custom_components/pandora_patiobar/media_player.py
@@ -102,7 +102,7 @@ class PatiobarMediaPlayer(CoordinatorEntity, MediaPlayerEntity):
         else:
             state = MediaPlayerState.PAUSED
             
-        _LOGGER.info("🎵 MEDIA PLAYER STATE: is_running=%s, is_playing=%s -> %s", is_running, is_playing, state)
+        _LOGGER.warning("🎵 MEDIA PLAYER STATE: is_running=%s, is_playing=%s -> %s", is_running, is_playing, state)
         return state
 
     @property
@@ -200,12 +200,12 @@ class PatiobarMediaPlayer(CoordinatorEntity, MediaPlayerEntity):
 
     async def async_media_play(self) -> None:
         """Send play command."""
-        _LOGGER.info("🎵 MEDIA PLAYER: async_media_play() called")
+        _LOGGER.warning("🎵 MEDIA PLAYER: async_media_play() called")
         await self.coordinator.async_media_play()
 
     async def async_media_pause(self) -> None:
         """Send pause command."""
-        _LOGGER.info("🎵 MEDIA PLAYER: async_media_pause() called")
+        _LOGGER.warning("🎵 MEDIA PLAYER: async_media_pause() called")
         await self.coordinator.async_media_pause()
 
     async def async_media_next_track(self) -> None:


### PR DESCRIPTION
- Media player state logging back to WARNING for visibility
- Play/pause command logging back to WARNING
- Websocket event logging back to WARNING
- Playing state change logging back to WARNING
- Reduces log verbosity while keeping important state changes visible